### PR TITLE
Align text 100px from left edge

### DIFF
--- a/style.css
+++ b/style.css
@@ -265,8 +265,8 @@ img, video{
 
  .hero-container {
      width: 100%;
-     max-width: 1200px;
-     margin: 0 auto;
+     max-width: none;
+     margin: 0;
      position: relative; /* anchor scroll rail and hero content */
  }
 
@@ -825,7 +825,7 @@ font-size: 30px;
 .nex-hero-left {
   position: absolute;
   top: 50%; /* vertically center */
-  left: -494px; /* pushed near left edge with 80px gap from scroll bar */
+  left: 100px; /* keep text 100px from the left edge */
   max-width: 400px; /* narrower text block */
   transform: translateY(-50%); /* vertically center adjustment */
   z-index: 120; /* ensure above dashboard/cards and snow */
@@ -1000,14 +1000,14 @@ font-size: 30px;
 
 @media (max-width: 900px) {
   .nex-hero { padding-top: 120px; }
-  .nex-hero-left { position: relative; left: 20px; top: 0; }
+  .nex-hero-left { position: relative; left: 20px; top: 0; transform: none; }
 }
 
 /* Removed readability overlay per request */
 .nex-hero-left {
   position: absolute;
   top: 50%; /* vertically center */
-  left: 94px; /* pushed near left edge with 80px gap from scroll bar */
+  left: 100px; /* keep text 100px from the left edge */
   max-width: 400px; /* narrower text block */
   transform: translateY(-50%); /* vertically center adjustment */
   z-index: 120; /* ensure above dashboard/cards and snow */


### PR DESCRIPTION
Aligns the hero text block 100px from the left edge of the screen as per user request.

The hero container was previously centered with a max-width, which prevented direct viewport alignment. This PR makes the container full-width and adjusts the text block's left offset.

---
<a href="https://cursor.com/background-agent?bcId=bc-7928f4ac-20dd-4694-8f57-dc3bf4b6679d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7928f4ac-20dd-4694-8f57-dc3bf4b6679d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

