### PR TITLE
Fix image object fit and background size

### DIFF
--- a/style.css
+++ b/style.css
@@ -568,12 +568,13 @@ font-size: 30px;
 }
 
 .articles-cards .card img{
-    height: 290px;
-    width: 400px;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    display: block;
     border-radius: 20px;
-    margin-top: 200px;
-    margin: 18px 10px;
-    margin-left: 15px;
+    margin: 0;
     position: relative;
 }
 


### PR DESCRIPTION
Ensure card images use `object-fit: cover` and fill their containers.

---
<a href="https://cursor.com/background-agent?bcId=bc-25a9f60f-424d-4f99-a55e-c7a205b8b566">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25a9f60f-424d-4f99-a55e-c7a205b8b566">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

